### PR TITLE
Composite widget

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -23,6 +23,7 @@ require('app/models/widgets/embed_widget');
 require('app/models/widgets/youtube_widget');
 require('app/models/widgets/rss_widget');
 require('app/models/widgets/tweet_widget');
+require('app/models/widgets/composite_widget');
 
 require('app/models/sources/source');
 require('app/models/sources/periodic_source');
@@ -38,6 +39,8 @@ require('app/models/sources/twitter_timeline_source');
 
 require('app/views/gridster_view');
 require('app/views/last_updated_view');
+
+require('app/models/widget_factory');
 
 require('app/controllers/dashboard_controller');
 

--- a/app/models/widget_factory.js
+++ b/app/models/widget_factory.js
@@ -1,0 +1,19 @@
+Dashboard.WidgetFactory = Ember.Object.create({
+
+  fromDef: function(widgetDef, sources) {
+    sources = sources || {};
+    var pos = widgetDef.pos;
+    var size = widgetDef.size || [1, 1];
+    var widgetArgs = widgetDef.args || {};
+
+    if (widgetDef.source) {
+      var sourceArgs = widgetDef.sourceArgs || {};
+      widgetArgs.source =
+        sources[widgetDef.source] || eval(widgetDef.source).create(sourceArgs);
+    }
+
+    return eval(widgetDef.widget).create($.extend(widgetArgs, {
+      row: pos[0], col: pos[1], sizex: size[0], sizey: size[1]
+    }));
+  }
+});

--- a/app/models/widgets/composite_widget.js
+++ b/app/models/widgets/composite_widget.js
@@ -1,0 +1,39 @@
+Dashboard.CompositeWidget = Dashboard.Widget.extend({
+  sourceData: 0,
+  widgets: [],
+
+  autoRotate: true,
+  rotatePeriod: 10000,
+
+  widgetInstances: function() {
+    var overrideArgs = {
+      pos: [this.get('row'), this.get('col')],
+      size: [this.get('sizex'), this.get('sizey')]
+    };
+
+    return this.get('widgets').map(function(widgetDef) {
+      return Dashboard.WidgetFactory.fromDef(
+        $.extend(widgetDef, overrideArgs));
+    });
+  }.property('widgets'),
+
+  currentWidget: function() {
+    return this.get('widgetInstances')[this.get('content')];
+  }.property('widgetInstances', 'content'),
+
+  widgetView: function() {
+    return this.get('currentWidget.widgetView');
+  }.property('currentWidget'),
+
+  init: function() {
+    this._super();
+
+    if(this.get('autoRotate')) {
+      var that = this;
+      setInterval(function() {
+        var next = (that.get('sourceData') + 1) % that.get('widgets').length;
+        that.set('sourceData', next);
+      }, this.get('rotatePeriod'));
+    }
+  }
+});

--- a/app/models/widgets/widget.js
+++ b/app/models/widgets/widget.js
@@ -15,7 +15,7 @@ Dashboard.Widget = Ember.Object.extend({
 
   widgetView: function() {
     var that = this;
-    return Ember.View.create({
+    return Ember.View.extend({
       templateName: that.get('templateName'),
       classNames: that.get('classNames'),
       controller: that

--- a/app/routes/dashboard_route.js
+++ b/app/routes/dashboard_route.js
@@ -8,19 +8,7 @@ Dashboard.DashboardRoute = Ember.Route.extend({
     });
 
     var widgets = DashboardConfig.grid.widgets.map(function(widgetDef) {
-      var pos = widgetDef.pos;
-      var size = widgetDef.size || [1, 1];
-      var widgetArgs = widgetDef.args || {};
-
-      if (widgetDef.source) {
-        var sourceArgs = widgetDef.sourceArgs || {};
-        widgetArgs.source =
-          sources[widgetDef.source] || eval(widgetDef.source).create(sourceArgs);
-      }
-
-      return eval(widgetDef.widget).create($.extend(widgetArgs, {
-        row: pos[0], col: pos[1], sizex: size[0], sizey: size[1]
-      }));
+      return Dashboard.WidgetFactory.fromDef(widgetDef, sources);
     });
 
     controller.set('content', widgets);

--- a/app/templates/gridster.hbs
+++ b/app/templates/gridster.hbs
@@ -6,7 +6,9 @@
         {{bindAttr data-sizex="sizex"}}
         {{bindAttr data-sizey="sizey"}}
         class="gs_w">
-      {{view widgetView}}
+      {{#with widgetView as wv}}
+        {{view wv}}
+      {{/with}}
     </li>
     {{/each}}
   </ul>


### PR DESCRIPTION
This pull request adds an abstract widget class which allows the allocation of more than one widget to the same position in the grid. It incorporates an embedded rotation logic which rotates between the various widgets in a round-robin manner every 10 seconds. A usage example is:

``` javascript
{
  pos: [1, 3],
  widget: 'Dashboard.CompositeWidget',
  args: {
    widgets: [
      {
        widget: 'Dashboard.ClockWidget',
        source: 'Dashboard.TimeSource'
      },
      {
        widget: 'Dashboard.WeatherWidget',
        source: 'Dashboard.WeatherSource',
        sourceArgs: { woeId: 742676 }
      }
    ]
  }
}
```

The widget does not require an attached source. However, if a source is attached, it is used to change the widget shown at any given time, being expected data in the form of widget numeric indices:

``` javascript
rotateSource: {
  className: 'Dashboard.PeriodicSource',
  args: {
    period: 2000,
    dataUpdate: function(callback) {
      callback(Math.floor(Math.random() * 2));
    }
  }
}

(...)

{
  pos: [1, 3],
  widget: 'Dashboard.CompositeWidget',
  source: 'rotateSource',
  args: {
    autoRotate: false,
    widgets: [
      {
        widget: 'Dashboard.ClockWidget',
        source: 'Dashboard.TimeSource'
      },
      {
        widget: 'Dashboard.WeatherWidget',
        source: 'Dashboard.WeatherSource',
        sourceArgs: { woeId: 742676 }
      }
    ]
  }
}
```
