### PR TITLE
Add a grunt option for faster development

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,6 +2,7 @@ module.exports = function(grunt) {
 
   // build config command-line keys
   var configKey = grunt.option('config') || 'default';
+  var devConfig = grunt.option('dev');
 
   // files and settings derived from build config
   var lessConfigFile = "config-" + configKey + ".less";
@@ -13,6 +14,8 @@ module.exports = function(grunt) {
     src: "package.json",
     dest: "build/dependencies"
   });
+
+  var uglifyTask = devConfig ? 'copy:uglify' : 'uglify';
 
   grunt.initConfig({
 
@@ -95,15 +98,28 @@ module.exports = function(grunt) {
       "<%= buildOptions.distPath %>/application.min.js": "<%= buildOptions.buildPath %>/application.js"
     },
 
+    // copies all files from one place to another
+    copy: {
+      uglify: {
+        files: {
+          "<%= buildOptions.distPath %>/application.min.js":
+            "<%= buildOptions.buildPath %>/application.js",
+
+          "<%= buildOptions.distPath %>/application.min.js.map":
+            "<%= buildOptions.buildPath %>/application.js.map"
+        }
+      }
+    },
+
     // watches files for changes
     watch: {
       build_code: {
         files: ['package.json'],
-        tasks: ['cdndeps', 'emberTemplates', 'neuter', 'uglify']
+        tasks: ['cdndeps', 'emberTemplates', 'neuter', uglifyTask]
       },
       application_code: {
         files: ['app/**/*.js'],
-        tasks: ['neuter', 'uglify']
+        tasks: ['neuter', uglifyTask]
       },
       css_stylesheets: {
         files: ['app/css/**/*.css'],
@@ -115,7 +131,7 @@ module.exports = function(grunt) {
       },
       handlebars_templates: {
         files: ['app/templates/**/*.hbs'],
-        tasks: ['emberTemplates', 'neuter', 'uglify']
+        tasks: ['emberTemplates', 'neuter', uglifyTask]
       }
     }
   });
@@ -126,8 +142,9 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-ember-templates');
   grunt.loadNpmTasks('grunt-neuter');
   grunt.loadNpmTasks('grunt-contrib-uglify');
+  grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-watch');
 
-  grunt.registerTask('build', ['less', 'cssmin', 'cdndeps', 'emberTemplates', 'neuter', 'uglify']);
+  grunt.registerTask('build', ['less', 'cssmin', 'cdndeps', 'emberTemplates', 'neuter', uglifyTask]);
   grunt.registerTask('default', ['build', 'watch']);
 };

--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ The `node_modules/` folder is not tracked by version control.
 Once all development dependencies are installed, the development tasks can be
 started with
 
-    grunt
+    grunt --dev
 
 This will build development versions of the application and start watching for
-any changes. `Gruntfile.js` orchestrates things here. If you simply want to build
-the application once, just do
+any changes. `Gruntfile.js` orchestrates things here and the `--dev` option skips
+minification of JavaScript code. If you simply want to build the application once
+with minification enabled, just do
 
     grunt build
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "grunt-cdndeps": "0.2.0",
     "grunt-neuter": "0.6.0",
     "grunt-contrib-uglify": "0.4.0",
+    "grunt-contrib-copy": "0.5.0",
     "grunt-ember-templates": "0.4.20",
     "grunt-contrib-cssmin": "0.9.0",
     "assemble-less": "0.7.0",


### PR DESCRIPTION
Right now, the `--dev` option just skips minification of JavaScript code. In the future, any option which makes development faster (which may not be suitable for production) should be used with this development option.
