### PR TITLE
Update dev dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,24 +3,24 @@
   "version": "1.0.0",
   "main": "Gruntfile.js",
   "repository": "",
-
   "devDependencies": {
-    "grunt": "0.4.4",
-    "grunt-contrib-clean": "0.5.0",
-    "grunt-curl": "1.4.0",
-    "grunt-cdndeps": "0.2.0",
-    "grunt-neuter": "0.6.0",
-    "grunt-contrib-uglify": "0.4.0",
-    "grunt-contrib-copy": "0.5.0",
-    "grunt-ember-templates": "0.4.20",
-    "grunt-contrib-cssmin": "0.9.0",
     "assemble-less": "0.7.0",
-    "grunt-contrib-watch": "0.6.1"
+    "ember-template-compiler": "^1.8.0",
+    "grunt": "0.4.5",
+    "grunt-cdndeps": "0.2.0",
+    "grunt-contrib-clean": "0.6.0",
+    "grunt-contrib-copy": "0.8.2",
+    "grunt-contrib-cssmin": "0.14.0",
+    "grunt-contrib-uglify": "0.9.2",
+    "grunt-contrib-watch": "0.6.1",
+    "grunt-curl": "2.2.0",
+    "grunt-ember-templates": "0.4.20",
+    "grunt-neuter": "0.6.0",
+    "handlebars": "^1.3.0"
   },
-
   "cdnDeps": [
     "//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.js",
-    "//cdnjs.cloudflare.com/ajax/libs/handlebars.js/1.0.0/handlebars.js",
+    "//cdnjs.cloudflare.com/ajax/libs/handlebars.js/1.3.0/handlebars.js",
     "//cdnjs.cloudflare.com/ajax/libs/ember.js/1.1.2/ember.js",
     "//cdnjs.cloudflare.com/ajax/libs/jquery.gridster/0.1.0/jquery.gridster.min.js",
     "//cdnjs.cloudflare.com/ajax/libs/jquery.atmosphere/2.1.2/jquery.atmosphere.js",


### PR DESCRIPTION
It seems that Mucuchies does not build cleanly now, possibly due to a change in the `grunt-ember-templates` dependency. When I do a fresh clone of the project and try to `npm install` it, the following warning appears:

```
npm WARN EPEERINVALID grunt-ember-templates@0.4.20 requires a peer of ember-template-compiler@>=1 <2 but none was installed.
```

If I ignore the warning and try to build the dashboard anyway, `grunt` presents me with the following error:

```
Loading "ember_templates.js" tasks...ERROR
>> Error: Cannot find module 'ember-template-compiler'
Warning: Task "emberTemplates" not found. Use --force to continue.

Aborted due to warnings.
```

This PR updates all the dev dependencies, with which the project build stops yielding warnings. I updated the Handlebars client-side dependency in order to match the one used by `grunt`, but that was not strictly necessary as the Handlebars version set in this PR is compatible with the old one.
